### PR TITLE
Implementing HTML Element properties getters and setters

### DIFF
--- a/junit-tests/src/test/java/org/testmonkeys/webpages/pageObjects/HtmlElementsPageObject.java
+++ b/junit-tests/src/test/java/org/testmonkeys/webpages/pageObjects/HtmlElementsPageObject.java
@@ -4,10 +4,14 @@ import org.testmonkeys.koshmar.core.page.Page;
 import org.testmonkeys.koshmar.pageobjects.AbstractPage;
 import org.testmonkeys.koshmar.pageobjects.ElementAccessor;
 import org.testmonkeys.koshmar.pageobjects.PageAccessor;
+import org.testmonkeys.koshmar.pageobjects.elements.GenericWebElement;
 import org.testmonkeys.koshmar.pageobjects.elements.Input;
 
 @PageAccessor(name="HtmlElements",url = "")
 public class HtmlElementsPageObject extends AbstractPage {
+
+    @ElementAccessor(elementName = "header", byXPath = "//h1")
+    private GenericWebElement header;
 
     @ElementAccessor(elementName="input",byId = "name_3_firstname")
     private Input firstName;
@@ -28,5 +32,9 @@ public class HtmlElementsPageObject extends AbstractPage {
 
     public Input styledInput(){
         return styledInput;
+    }
+
+    public GenericWebElement header() {
+        return header;
     }
 }

--- a/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/AttributesTest.java
+++ b/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/AttributesTest.java
@@ -2,10 +2,7 @@ package org.testmonkeys.webpages.tests.htmlelement;
 
 import org.junit.Test;
 import org.testmonkeys.koshmar.pageobjects.elements.html.HtmlAttribute;
-import org.testmonkeys.webpages.pageObjects.HtmlElementsPageObject;
 import org.testmonkeys.webpages.tests.AbstractHtmlElementPageTest;
-import org.testmonkeys.webpages.tests.AbstractRegistrationPageTest;
-
 
 import java.util.List;
 
@@ -27,11 +24,11 @@ public class AttributesTest extends AbstractHtmlElementPageTest {
     @Test
     public void get_hasAttributes() {
         List<HtmlAttribute> attrs = page.firstName().getHtmlElement().getAttributes();
-        assertThat("value attr",attrs, hasItem(new HtmlAttribute("value", "")));
-        assertThat("id attr",attrs, hasItem(new HtmlAttribute("id", "name_3_firstname")));
-        assertThat("class attr",attrs, hasItem(new HtmlAttribute("class", "input_fields  piereg_validate[required] input_fields")));
-        assertThat("type attr",attrs, hasItem(new HtmlAttribute("type", "text")));
-        assertThat("disabled attr",attrs, hasItem(new HtmlAttribute("disabled", "")));
+        assertThat("value attr", attrs, hasItem(new HtmlAttribute("value", "")));
+        assertThat("id attr", attrs, hasItem(new HtmlAttribute("id", "name_3_firstname")));
+        assertThat("class attr", attrs, hasItem(new HtmlAttribute("class", "input_fields  piereg_validate[required] input_fields")));
+        assertThat("type attr", attrs, hasItem(new HtmlAttribute("type", "text")));
+        assertThat("disabled attr", attrs, hasItem(new HtmlAttribute("disabled", "")));
     }
 
     @Test

--- a/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/DraggableTests.java
+++ b/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/DraggableTests.java
@@ -1,0 +1,28 @@
+package org.testmonkeys.webpages.tests.htmlelement;
+
+import org.junit.Test;
+import org.testmonkeys.webpages.tests.AbstractHtmlElementPageTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class DraggableTests extends AbstractHtmlElementPageTest {
+
+    @Test
+    public void get_draggable() {
+        boolean res = page.header().getHtmlElement().getDraggable();
+        assertThat(res, is(false));
+    }
+
+    @Test
+    public void set_draggable() {
+        boolean res = page.header().getHtmlElement().getDraggable();
+        assertThat(res, is(false));
+        page.header().getHtmlElement().setDraggable(true);
+
+        res = page.header().getHtmlElement().getDraggable();
+        assertThat(res, is(true));
+    }
+
+
+}

--- a/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/HiddenTests.java
+++ b/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/HiddenTests.java
@@ -1,0 +1,28 @@
+package org.testmonkeys.webpages.tests.htmlelement;
+
+import org.junit.Test;
+import org.testmonkeys.webpages.tests.AbstractHtmlElementPageTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class HiddenTests extends AbstractHtmlElementPageTest {
+
+    @Test
+    public void get_Hidden() {
+        boolean res = page.header().getHtmlElement().getHidden();
+        assertThat(res, is(false));
+    }
+
+    @Test
+    public void set_Hidden() {
+        boolean res = page.header().getHtmlElement().getHidden();
+        assertThat(res, is(false));
+        page.header().getHtmlElement().setHidden(true);
+
+        res = page.header().getHtmlElement().getHidden();
+        assertThat(res, is(true));
+    }
+
+
+}

--- a/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/InnerHtmlTests.java
+++ b/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/InnerHtmlTests.java
@@ -1,0 +1,27 @@
+package org.testmonkeys.webpages.tests.htmlelement;
+
+import org.junit.Test;
+import org.testmonkeys.webpages.tests.AbstractHtmlElementPageTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class InnerHtmlTests extends AbstractHtmlElementPageTest {
+
+    @Test
+    public void get_innerHtml() {
+        String res = page.header().getHtmlElement().getInnerHtml();
+        assertThat(res, is("Html Element "));
+    }
+
+    @Test
+    public void set_innerHtml() {
+        String res = page.header().getHtmlElement().getInnerHtml();
+        assertThat(res, is("Html Element "));
+        page.header().getHtmlElement().setInnerHtml("injected");
+        res = page.header().getHtmlElement().getInnerHtml();
+        assertThat(res, is("injected"));
+    }
+
+
+}

--- a/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/OuterHtmlTests.java
+++ b/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/OuterHtmlTests.java
@@ -1,0 +1,27 @@
+package org.testmonkeys.webpages.tests.htmlelement;
+
+import org.junit.Test;
+import org.testmonkeys.webpages.tests.AbstractHtmlElementPageTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class OuterHtmlTests extends AbstractHtmlElementPageTest {
+
+    @Test
+    public void get_outerHtml() {
+        String res = page.header().getHtmlElement().getOuterHtml();
+        assertThat(res, is("<h1 class=\"entry-title\">Html Element </h1>"));
+    }
+
+    @Test
+    public void set_outerHtml() {
+        String res = page.header().getHtmlElement().getOuterHtml();
+        assertThat(res, is("<h1 class=\"entry-title\">Html Element </h1>"));
+        page.header().getHtmlElement().setOuterHtml("<h1 class=\"entry-title1\">injected</h1>");
+        res = page.header().getHtmlElement().getOuterHtml();
+        assertThat(res, is("<h1 class=\"entry-title1\">injected</h1>"));
+    }
+
+
+}

--- a/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/StyleTest.java
+++ b/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/StyleTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
 
 public class StyleTest extends AbstractHtmlElementPageTest {
 
@@ -21,8 +22,20 @@ public class StyleTest extends AbstractHtmlElementPageTest {
     }
 
     @Test
+    public void get_hasStyle_specific() {
+        String style = page.styledInput().getHtmlElement().getStyle("border-right-width");
+        assertThat(style, is("2px"));
+    }
+
+    @Test
     public void get_noAttributes() {
         List<HtmlAttribute> attrs = page.firstName2().getHtmlElement().getAttributes();
         assertThat("attributes size", attrs.size(), is(0));
+    }
+
+    @Test
+    public void get_invalidKeyStyle_specific() {
+        String style = page.styledInput().getHtmlElement().getStyle("bor1der-right-width");
+        assertThat(style, is(nullValue()));
     }
 }

--- a/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/StyleTest.java
+++ b/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/StyleTest.java
@@ -2,7 +2,6 @@ package org.testmonkeys.webpages.tests.htmlelement;
 
 import org.junit.Test;
 import org.testmonkeys.koshmar.pageobjects.elements.html.HtmlAttribute;
-import org.testmonkeys.webpages.pageObjects.HtmlElementsPageObject;
 import org.testmonkeys.webpages.tests.AbstractHtmlElementPageTest;
 
 import java.util.List;
@@ -10,7 +9,6 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
 
 public class StyleTest extends AbstractHtmlElementPageTest {
 

--- a/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/TabIndexTests.java
+++ b/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/TabIndexTests.java
@@ -1,0 +1,28 @@
+package org.testmonkeys.webpages.tests.htmlelement;
+
+import org.junit.Test;
+import org.testmonkeys.webpages.tests.AbstractHtmlElementPageTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class TabIndexTests extends AbstractHtmlElementPageTest {
+
+    @Test
+    public void get_tabIndex() {
+        int res = page.header().getHtmlElement().getTabIndex();
+        assertThat(res, is(-1));
+    }
+
+    @Test
+    public void set_tabIndex() {
+        int res = page.header().getHtmlElement().getTabIndex();
+        assertThat(res, is(-1));
+        page.header().getHtmlElement().setTabIndex(1);
+
+        res = page.header().getHtmlElement().getTabIndex();
+        assertThat(res, is(1));
+    }
+
+
+}

--- a/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/TagNameTests.java
+++ b/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/TagNameTests.java
@@ -1,0 +1,18 @@
+package org.testmonkeys.webpages.tests.htmlelement;
+
+import org.junit.Test;
+import org.testmonkeys.webpages.tests.AbstractHtmlElementPageTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class TagNameTests extends AbstractHtmlElementPageTest {
+
+    @Test
+    public void get_tagName() {
+        String res = page.header().getHtmlElement().getTagName();
+        assertThat(res, is("H1"));
+    }
+
+
+}

--- a/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/TitleTests.java
+++ b/junit-tests/src/test/java/org/testmonkeys/webpages/tests/htmlelement/TitleTests.java
@@ -1,0 +1,27 @@
+package org.testmonkeys.webpages.tests.htmlelement;
+
+import org.junit.Test;
+import org.testmonkeys.webpages.tests.AbstractHtmlElementPageTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class TitleTests extends AbstractHtmlElementPageTest {
+
+    @Test
+    public void get_title() {
+        String res = page.header().getHtmlElement().getTitle();
+        assertThat(res, is(""));
+    }
+
+    @Test
+    public void set_title() {
+        String res = page.header().getHtmlElement().getTitle();
+        assertThat(res, is(""));
+        page.header().getHtmlElement().setTitle("injected title");
+        res = page.header().getHtmlElement().getTitle();
+        assertThat(res, is("injected title"));
+    }
+
+
+}

--- a/koshmar/src/main/java/org/testmonkeys/koshmar/pageobjects/elements/html/HtmlElement.java
+++ b/koshmar/src/main/java/org/testmonkeys/koshmar/pageobjects/elements/html/HtmlElement.java
@@ -7,26 +7,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.testmonkeys.koshmar.pageobjects.elements.html.JsScripts.*;
+
 /**
  * HtmlElement provides access to functionality available for any Element present in DOM
  */
 public class HtmlElement {
 
-    private final String GET_ATTRIBUTE_SCRIPT = "/javaScript/htmlElement/getAttributes.js";
-    private final String GET_COMPUTED_STYLE_SCRIPT = "/javaScript/htmlElement/getComputedStyle.js";
-    private final String GET_INNER_HTML_SCRIPT = "/javaScript/htmlElement/getInnerHtml.js";
-    private final String SET_INNER_HTML_SCRIPT = "/javaScript/htmlElement/setInnerHtml.js";
-    private final String GET_OUTER_HTML_SCRIPT = "/javaScript/htmlElement/getOuterHtml.js";
-    private final String SET_OUTER_HTML_SCRIPT = "/javaScript/htmlElement/setOuterHtml.js";
-    private final String GET_TAG_NAME_SCRIPT = "/javaScript/htmlElement/getTagName.js";
-    private final String GET_TAG_HIDDEN_SCRIPT = "/javaScript/htmlElement/getHidden.js";
-    private final String SET_TAG_HIDDEN_SCRIPT = "/javaScript/htmlElement/setHidden.js";
-    private final String GET_TAB_INDEX_SCRIPT = "/javaScript/htmlElement/getTabIndex.js";
-    private final String SET_TAB_INDEX_SCRIPT = "/javaScript/htmlElement/setTabIndex.js";
-    private final String GET_TITLE_SCRIPT = "/javaScript/htmlElement/getTitle.js";
-    private final String SET_TITLE_SCRIPT = "/javaScript/htmlElement/setTitle.js";
-    private final String GET_DRAGGABLE_SCRIPT = "/javaScript/htmlElement/getDraggable.js";
-    private final String SET_DRAGGABLE_SCRIPT = "/javaScript/htmlElement/setDraggable.js";
+
 
     private AbstractComponent component;
 
@@ -40,7 +28,7 @@ public class HtmlElement {
      * @return List of HtmlAttribute
      */
     public List<HtmlAttribute> getAttributes() {
-        Object result = new ExecuteJSScript(component, GET_ATTRIBUTE_SCRIPT).execute();
+        Object result = new ExecuteJSScript(component, GET_ATTRIBUTE).execute();
 
         List<HtmlAttribute> attributes = new ArrayList<>();
         try {
@@ -83,7 +71,7 @@ public class HtmlElement {
      * @return Map of style-name to style-value pairs
      */
     public Map<String, String> getStyle() {
-        Object jsResult = new ExecuteJSScript(component, GET_COMPUTED_STYLE_SCRIPT).execute();
+        Object jsResult = new ExecuteJSScript(component, GET_COMPUTED_STYLE).execute();
 
         Map<String, String> result;
         try {
@@ -100,7 +88,7 @@ public class HtmlElement {
      * @return string value of the innerHTML
      */
     public String getInnerHtml() {
-        Object jsResult = new ExecuteJSScript(component, GET_INNER_HTML_SCRIPT).execute();
+        Object jsResult = new ExecuteJSScript(component, GET_INNER_HTML).execute();
         return (String) jsResult;
     }
 
@@ -110,7 +98,7 @@ public class HtmlElement {
      * @param value - new value of the innerHTML
      */
     public void setInnerHtml(String value) {
-        new ExecuteJSScript(component, SET_INNER_HTML_SCRIPT, value).execute();
+        new ExecuteJSScript(component, SET_INNER_HTML, value).execute();
     }
 
     /**
@@ -119,7 +107,7 @@ public class HtmlElement {
      * @return string value of the outerHTML
      */
     public String getOuterHtml() {
-        Object jsResult = new ExecuteJSScript(component, GET_OUTER_HTML_SCRIPT).execute();
+        Object jsResult = new ExecuteJSScript(component, GET_OUTER_HTML).execute();
         return (String) jsResult;
     }
 
@@ -129,7 +117,7 @@ public class HtmlElement {
      * @param value - new value of the outerHTML
      */
     public void setOuterHtml(String value) {
-        new ExecuteJSScript(component, SET_OUTER_HTML_SCRIPT, value).execute();
+        new ExecuteJSScript(component, SET_OUTER_HTML, value).execute();
     }
 
     /**
@@ -138,7 +126,7 @@ public class HtmlElement {
      * @return string - name of the tag
      */
     public String getTagName() {
-        Object jsResult = new ExecuteJSScript(component, GET_TAG_NAME_SCRIPT).execute();
+        Object jsResult = new ExecuteJSScript(component, GET_TAG_NAME).execute();
         return (String) jsResult;
     }
 
@@ -148,7 +136,7 @@ public class HtmlElement {
      * @return true if element is hidden
      */
     public boolean getHidden() {
-        Object jsResult = new ExecuteJSScript(component, GET_TAG_HIDDEN_SCRIPT).execute();
+        Object jsResult = new ExecuteJSScript(component, GET_TAG_HIDDEN).execute();
         return (boolean) jsResult;
     }
 
@@ -158,7 +146,7 @@ public class HtmlElement {
      * @param value - boolean value
      */
     public void setHidden(boolean value) {
-        new ExecuteJSScript(component, SET_TAG_HIDDEN_SCRIPT, value).execute();
+        new ExecuteJSScript(component, SET_TAG_HIDDEN, value).execute();
     }
 
     /**
@@ -167,7 +155,7 @@ public class HtmlElement {
      * @return int index or -1 if element does not have a Tab Index
      */
     public int getTabIndex() {
-        Object jsResult = new ExecuteJSScript(component, GET_TAB_INDEX_SCRIPT).execute();
+        Object jsResult = new ExecuteJSScript(component, GET_TAB_INDEX).execute();
         return (int) ((long) jsResult);
     }
 
@@ -177,7 +165,7 @@ public class HtmlElement {
      * @param value - int index
      */
     public void setTabIndex(int value) {
-        new ExecuteJSScript(component, SET_TAB_INDEX_SCRIPT, value).execute();
+        new ExecuteJSScript(component, SET_TAB_INDEX, value).execute();
     }
 
     /**
@@ -186,7 +174,7 @@ public class HtmlElement {
      * @return string title
      */
     public String getTitle() {
-        Object jsResult = new ExecuteJSScript(component, GET_TITLE_SCRIPT).execute();
+        Object jsResult = new ExecuteJSScript(component, GET_TITLE).execute();
         return (String) jsResult;
     }
 
@@ -196,7 +184,7 @@ public class HtmlElement {
      * @param value - string title
      */
     public void setTitle(String value) {
-        new ExecuteJSScript(component, SET_TITLE_SCRIPT, value).execute();
+        new ExecuteJSScript(component, SET_TITLE, value).execute();
     }
 
     /**
@@ -205,7 +193,7 @@ public class HtmlElement {
      * @return boolean true if draggable
      */
     public boolean getDraggable() {
-        Object jsResult = new ExecuteJSScript(component, GET_DRAGGABLE_SCRIPT).execute();
+        Object jsResult = new ExecuteJSScript(component, GET_DRAGGABLE).execute();
         return (boolean) jsResult;
     }
 
@@ -215,6 +203,6 @@ public class HtmlElement {
      * @param value - boolean true to enable draggable
      */
     public void setDraggable(boolean value) {
-        new ExecuteJSScript(component, SET_DRAGGABLE_SCRIPT, value).execute();
+        new ExecuteJSScript(component, SET_DRAGGABLE, value).execute();
     }
 }

--- a/koshmar/src/main/java/org/testmonkeys/koshmar/pageobjects/elements/html/HtmlElement.java
+++ b/koshmar/src/main/java/org/testmonkeys/koshmar/pageobjects/elements/html/HtmlElement.java
@@ -25,6 +25,8 @@ public class HtmlElement {
     private final String SET_TAB_INDEX_SCRIPT = "/javaScript/htmlElement/setTabIndex.js";
     private final String GET_TITLE_SCRIPT = "/javaScript/htmlElement/getTitle.js";
     private final String SET_TITLE_SCRIPT = "/javaScript/htmlElement/setTitle.js";
+    private final String GET_DRAGGABLE_SCRIPT = "/javaScript/htmlElement/getDraggable.js";
+    private final String SET_DRAGGABLE_SCRIPT = "/javaScript/htmlElement/setDraggable.js";
 
     private AbstractComponent component;
 
@@ -195,5 +197,24 @@ public class HtmlElement {
      */
     public void setTitle(String value) {
         new ExecuteJSScript(component, SET_TITLE_SCRIPT, value).execute();
+    }
+
+    /**
+     * Gets the Draggable property of the element
+     *
+     * @return boolean true if draggable
+     */
+    public boolean getDraggable() {
+        Object jsResult = new ExecuteJSScript(component, GET_DRAGGABLE_SCRIPT).execute();
+        return (boolean) jsResult;
+    }
+
+    /**
+     * Sets the Draggable property of the element
+     *
+     * @param value - boolean true to enable draggable
+     */
+    public void setDraggable(boolean value) {
+        new ExecuteJSScript(component, SET_DRAGGABLE_SCRIPT, value).execute();
     }
 }

--- a/koshmar/src/main/java/org/testmonkeys/koshmar/pageobjects/elements/html/HtmlElement.java
+++ b/koshmar/src/main/java/org/testmonkeys/koshmar/pageobjects/elements/html/HtmlElement.java
@@ -14,6 +14,18 @@ public class HtmlElement {
 
     private final String GET_ATTRIBUTE_SCRIPT = "/javaScript/htmlElement/getAttributes.js";
     private final String GET_COMPUTED_STYLE_SCRIPT = "/javaScript/htmlElement/getComputedStyle.js";
+    private final String GET_INNER_HTML_SCRIPT = "/javaScript/htmlElement/getInnerHtml.js";
+    private final String SET_INNER_HTML_SCRIPT = "/javaScript/htmlElement/setInnerHtml.js";
+    private final String GET_OUTER_HTML_SCRIPT = "/javaScript/htmlElement/getOuterHtml.js";
+    private final String SET_OUTER_HTML_SCRIPT = "/javaScript/htmlElement/setOuterHtml.js";
+    private final String GET_TAG_NAME_SCRIPT = "/javaScript/htmlElement/getTagName.js";
+    private final String GET_TAG_HIDDEN_SCRIPT = "/javaScript/htmlElement/getHidden.js";
+    private final String SET_TAG_HIDDEN_SCRIPT = "/javaScript/htmlElement/setHidden.js";
+    private final String GET_TAB_INDEX_SCRIPT = "/javaScript/htmlElement/getTabIndex.js";
+    private final String SET_TAB_INDEX_SCRIPT = "/javaScript/htmlElement/setTabIndex.js";
+    private final String GET_TITLE_SCRIPT = "/javaScript/htmlElement/getTitle.js";
+    private final String SET_TITLE_SCRIPT = "/javaScript/htmlElement/setTitle.js";
+
     private AbstractComponent component;
 
     public HtmlElement(AbstractComponent component) {
@@ -80,5 +92,108 @@ public class HtmlElement {
         return result;
     }
 
+    /**
+     * Gets the innerHTML property of the element
+     *
+     * @return string value of the innerHTML
+     */
+    public String getInnerHtml() {
+        Object jsResult = new ExecuteJSScript(component, GET_INNER_HTML_SCRIPT).execute();
+        return (String) jsResult;
+    }
 
+    /**
+     * Sets the innerHTML property of the element
+     *
+     * @param value - new value of the innerHTML
+     */
+    public void setInnerHtml(String value) {
+        new ExecuteJSScript(component, SET_INNER_HTML_SCRIPT, value).execute();
+    }
+
+    /**
+     * Gets the outerHTML property of the element
+     *
+     * @return string value of the outerHTML
+     */
+    public String getOuterHtml() {
+        Object jsResult = new ExecuteJSScript(component, GET_OUTER_HTML_SCRIPT).execute();
+        return (String) jsResult;
+    }
+
+    /**
+     * Sets the outerHTML property of the element
+     *
+     * @param value - new value of the outerHTML
+     */
+    public void setOuterHtml(String value) {
+        new ExecuteJSScript(component, SET_OUTER_HTML_SCRIPT, value).execute();
+    }
+
+    /**
+     * Gets the Tag Name of the element
+     *
+     * @return string - name of the tag
+     */
+    public String getTagName() {
+        Object jsResult = new ExecuteJSScript(component, GET_TAG_NAME_SCRIPT).execute();
+        return (String) jsResult;
+    }
+
+    /**
+     * Gets the Hidden property of the element
+     *
+     * @return true if element is hidden
+     */
+    public boolean getHidden() {
+        Object jsResult = new ExecuteJSScript(component, GET_TAG_HIDDEN_SCRIPT).execute();
+        return (boolean) jsResult;
+    }
+
+    /**
+     * Sets the Hidden property of the element
+     *
+     * @param value - boolean value
+     */
+    public void setHidden(boolean value) {
+        new ExecuteJSScript(component, SET_TAG_HIDDEN_SCRIPT, value).execute();
+    }
+
+    /**
+     * Gets the Tab Index of the element
+     *
+     * @return int index or -1 if element does not have a Tab Index
+     */
+    public int getTabIndex() {
+        Object jsResult = new ExecuteJSScript(component, GET_TAB_INDEX_SCRIPT).execute();
+        return (int) ((long) jsResult);
+    }
+
+    /**
+     * Sets the Tab Index of the element
+     *
+     * @param value - int index
+     */
+    public void setTabIndex(int value) {
+        new ExecuteJSScript(component, SET_TAB_INDEX_SCRIPT, value).execute();
+    }
+
+    /**
+     * Gets the Title property of the element, also known as hint text
+     *
+     * @return string title
+     */
+    public String getTitle() {
+        Object jsResult = new ExecuteJSScript(component, GET_TITLE_SCRIPT).execute();
+        return (String) jsResult;
+    }
+
+    /**
+     * Sets the Title property of the element, also known as hint text
+     *
+     * @param value - string title
+     */
+    public void setTitle(String value) {
+        new ExecuteJSScript(component, SET_TITLE_SCRIPT, value).execute();
+    }
 }

--- a/koshmar/src/main/java/org/testmonkeys/koshmar/pageobjects/elements/html/HtmlElement.java
+++ b/koshmar/src/main/java/org/testmonkeys/koshmar/pageobjects/elements/html/HtmlElement.java
@@ -83,6 +83,19 @@ public class HtmlElement {
     }
 
     /**
+     * Gets the style value by a specific key
+     *
+     * @param key to get style for
+     * @return string value representing the style or null if key not found
+     */
+    public String getStyle(String key) {
+        Map<String, String> styles = getStyle();
+        if (!styles.containsKey(key))
+            return null;
+        return styles.get(key);
+    }
+
+    /**
      * Gets the innerHTML property of the element
      *
      * @return string value of the innerHTML

--- a/koshmar/src/main/java/org/testmonkeys/koshmar/pageobjects/elements/html/JsScripts.java
+++ b/koshmar/src/main/java/org/testmonkeys/koshmar/pageobjects/elements/html/JsScripts.java
@@ -1,0 +1,19 @@
+package org.testmonkeys.koshmar.pageobjects.elements.html;
+
+public class JsScripts {
+    public static final String GET_ATTRIBUTE = "/javaScript/htmlElement/getAttributes.js";
+    public static final String GET_COMPUTED_STYLE = "/javaScript/htmlElement/getComputedStyle.js";
+    public static final String GET_INNER_HTML = "/javaScript/htmlElement/getInnerHtml.js";
+    public static final String SET_INNER_HTML = "/javaScript/htmlElement/setInnerHtml.js";
+    public static final String GET_OUTER_HTML = "/javaScript/htmlElement/getOuterHtml.js";
+    public static final String SET_OUTER_HTML = "/javaScript/htmlElement/setOuterHtml.js";
+    public static final String GET_TAG_NAME = "/javaScript/htmlElement/getTagName.js";
+    public static final String GET_TAG_HIDDEN = "/javaScript/htmlElement/getHidden.js";
+    public static final String SET_TAG_HIDDEN = "/javaScript/htmlElement/setHidden.js";
+    public static final String GET_TAB_INDEX = "/javaScript/htmlElement/getTabIndex.js";
+    public static final String SET_TAB_INDEX = "/javaScript/htmlElement/setTabIndex.js";
+    public static final String GET_TITLE = "/javaScript/htmlElement/getTitle.js";
+    public static final String SET_TITLE = "/javaScript/htmlElement/setTitle.js";
+    public static final String GET_DRAGGABLE = "/javaScript/htmlElement/getDraggable.js";
+    public static final String SET_DRAGGABLE = "/javaScript/htmlElement/setDraggable.js";
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/getDraggable.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/getDraggable.js
@@ -1,0 +1,3 @@
+function fun(element) {
+    return element.draggable;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/getHidden.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/getHidden.js
@@ -1,0 +1,3 @@
+function fun(element) {
+    return element.hidden;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/getInnerHtml.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/getInnerHtml.js
@@ -1,0 +1,3 @@
+function fun(element) {
+    return element.innerHTML;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/getOuterHtml.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/getOuterHtml.js
@@ -1,0 +1,3 @@
+function fun(element) {
+    return element.outerHTML;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/getTabIndex.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/getTabIndex.js
@@ -1,0 +1,3 @@
+function fun(element) {
+    return element.tabIndex;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/getTagName.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/getTagName.js
@@ -1,0 +1,3 @@
+function fun(element) {
+    return element.tagName;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/getTitle.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/getTitle.js
@@ -1,0 +1,3 @@
+function fun(element) {
+    return element.title;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/setDraggable.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/setDraggable.js
@@ -1,0 +1,3 @@
+function fun(element, value) {
+    return element.draggable = value;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/setHidden.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/setHidden.js
@@ -1,0 +1,3 @@
+function fun(element, value) {
+    return element.hidden = value;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/setInnerHtml.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/setInnerHtml.js
@@ -1,0 +1,3 @@
+function fun(element, value) {
+    return element.innerHTML = value;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/setOuterHtml.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/setOuterHtml.js
@@ -1,0 +1,3 @@
+function fun(element, value) {
+    return element.outerHTML = value;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/setTabIndex.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/setTabIndex.js
@@ -1,0 +1,3 @@
+function fun(element, value) {
+    return element.tabIndex = value;
+}

--- a/koshmar/src/main/resources/javaScript/htmlElement/setTitle.js
+++ b/koshmar/src/main/resources/javaScript/htmlElement/setTitle.js
@@ -1,0 +1,3 @@
+function fun(element, value) {
+    return element.title = value;
+}


### PR DESCRIPTION
adding support for the following properties:
1. innerHtml
2. outerHtml
3. tagName
4. tabIndex
5. title

Fixes issues #10, #11, #12, #16 and #17